### PR TITLE
Credential store's cred reference should be optional

### DIFF
--- a/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/CredentialStoreDefinition.java
+++ b/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/CredentialStoreDefinition.java
@@ -121,10 +121,11 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
             .build();
 
     static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE = 
-            CredentialReference.getAttributeBuilder("credential-reference", "credential-reference", false)
+            CredentialReference.getAttributeBuilder("credential-reference", "credential-reference", true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setCapabilityReference(CREDENTIAL_STORE_CAPABILITY, CREDENTIAL_STORE_RUNTIME_CAPABILITY)
                     .setStability(Stability.EXPERIMENTAL)
+                    .setRequired(false)
                     .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(HOST_NAME_DEF, NAMESPACE_DEF,


### PR DESCRIPTION
We can use other auth methods like jwt or certificates instead of the token