### PR TITLE
Add cert auth integration test without credential-reference

### DIFF
--- a/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCase.java
+++ b/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCase.java
@@ -4,7 +4,17 @@
  */
 package org.wildfly.extension.hashicorp.vault;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -21,6 +31,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.utility.MountableFile;
 
 /**
  * Elytron authentication-context with {@code ssl-context} match-rules and mutual TLS to Vault (HTTPS listener requires client certificate).
@@ -32,6 +43,10 @@ public class HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCas
 
     private static final String VAULT_TOKEN = "myroot";
     private static final String CREDENTIAL_STORE_NAME = "vault-mtls-store";
+    private static final String CERT_AUTH_STORE_NAME = "vault-cert-auth-store";
+    private static final String CERT_AUTH_CONTAINER_PATH = "/vault/certs/client-auth.crt";
+    private static final String CERT_AUTH_ROLE = "wildfly";
+    private static final String CERT_AUTH_POLICY = "admin";
     private static final VaultHttpsElytronSetup.SetupNames NAMES = VaultHttpsElytronSetup.SetupNames.mutualTls();
 
     private static final VaultContainerHttps<?> VAULT;
@@ -76,6 +91,86 @@ public class HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCas
         VaultHttpsElytronSetup.executeSuccess(managementClient, remove);
     }
 
+    /**
+     * Credential store with TLS certificate authentication (no {@code credential-reference}).
+     * The client certificate from the Elytron {@code authentication-context} authenticates to Vault directly
+     * via the {@code cert} auth method.
+     * <p><b>Passes when:</b> credential store add, add-alias, read-aliases, remove-alias, and credential store
+     * remove all complete with {@code outcome=success}.
+     */
+    @Test
+    public void testCredentialStoreWithCertAuthNoToken(@ArquillianResource ManagementClient managementClient) throws IOException {
+        PathAddress storeAddress = PathAddress.pathAddress(PathElement.pathElement("subsystem", "hashicorp-vault"))
+                .append("credential-store", CERT_AUTH_STORE_NAME);
+
+        ModelNode add = Util.createAddOperation(storeAddress);
+        add.get("host-address").set(VAULT.composeHttpsHostAddress());
+        add.get("authentication-context").set(NAMES.authenticationContext);
+        VaultHttpsElytronSetup.executeSuccess(managementClient, add);
+
+        ModelNode addAlias = Util.createOperation("add-alias", storeAddress);
+        addAlias.get("alias").set("secret/certtest.password");
+        addAlias.get("secret-value").set("s3cr3t");
+        VaultHttpsElytronSetup.executeSuccess(managementClient, addAlias);
+
+        ModelNode readAliases = Util.createOperation("read-aliases", storeAddress);
+        readAliases.get("path").set("secret/certtest");
+        readAliases.get("recursive").set(true);
+        ModelNode readResult = managementClient.getControllerClient().execute(readAliases);
+        assertEquals(SUCCESS, readResult.get(OUTCOME).asString(), "read-aliases should succeed: " + readResult);
+        List<ModelNode> aliases = readResult.get(RESULT).asList();
+        assertTrue(aliases.stream().anyMatch(n -> "secret/certtest.password".equals(n.asString())),
+                "Expected alias 'secret/certtest.password' in read-aliases result, got: " + aliases);
+
+        ModelNode removeAlias = Util.createOperation("remove-alias", storeAddress);
+        removeAlias.get("alias").set("secret/certtest.password");
+        VaultHttpsElytronSetup.executeSuccess(managementClient, removeAlias);
+
+        ModelNode remove = Util.createRemoveOperation(storeAddress);
+        remove.get("operation-headers", "allow-resource-service-restart").set(true);
+        VaultHttpsElytronSetup.executeSuccess(managementClient, remove);
+    }
+
+    /**
+     * Credential store without token and without cert auth enabled on Vault.
+     * The client certificate is presented at the TLS level but Vault has no {@code cert} auth method,
+     * so all login strategies fail.
+     * <p><b>Passes when:</b> the credential store add operation fails.
+     */
+    @Test
+    public void testCredentialStoreWithoutTokenFailsWhenCertAuthNotEnabled(@ArquillianResource ManagementClient managementClient) throws Exception {
+        VAULT.execInContainer("vault", "auth", "disable", "cert");
+
+        PathAddress storeAddress = PathAddress.pathAddress(PathElement.pathElement("subsystem", "hashicorp-vault"))
+                .append("credential-store", "vault-no-auth-store");
+        try {
+            ModelNode add = Util.createAddOperation(storeAddress);
+            add.get("host-address").set(VAULT.composeHttpsHostAddress());
+            add.get("authentication-context").set(NAMES.authenticationContext);
+
+            ModelNode response = managementClient.getControllerClient().execute(add);
+            assertNotEquals(SUCCESS, response.get(OUTCOME).asString(),
+                    "Credential store add should fail without token and without cert auth enabled on Vault");
+            assertTrue(response.get(FAILURE_DESCRIPTION).toString().contains("All login strategies failed"),
+                    "Expected 'All login strategies failed' in failure description, got: " + response.get(FAILURE_DESCRIPTION));
+        } finally {
+            ModelNode cleanup = Util.createRemoveOperation(storeAddress);
+            cleanup.get("operation-headers", "allow-resource-service-restart").set(true);
+            try { managementClient.getControllerClient().execute(cleanup); } catch (Exception ignored) { }
+
+            enableVaultCertAuth();
+        }
+    }
+
+    private static void enableVaultCertAuth() throws Exception {
+        // Disable first to make this idempotent (ignore errors if not enabled)
+        VAULT.execInContainer("vault", "auth", "disable", "cert");
+        VAULT.execInContainer("vault", "auth", "enable", "cert");
+        VAULT.execInContainer("vault", "write", "auth/cert/certs/" + CERT_AUTH_ROLE,
+                "display_name=" + CERT_AUTH_ROLE, "policies=" + CERT_AUTH_POLICY,
+                "certificate=@" + CERT_AUTH_CONTAINER_PATH);
+    }
+
     public static final class ElytronSetup implements ServerSetupTask {
 
         @Override
@@ -83,6 +178,11 @@ public class HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCas
             if (!VAULT.isRunning()) {
                 VAULT.start();
             }
+            Path clientCert = VAULT.getClientCertificateFiles().clientCertFile();
+            VAULT.copyFileToContainer(
+                    MountableFile.forHostPath(clientCert, 0644),
+                    CERT_AUTH_CONTAINER_PATH);
+            enableVaultCertAuth();
             VaultHttpsElytronSetup.install(managementClient, VAULT, NAMES, true);
         }
 


### PR DESCRIPTION
Add two test scenarios to the existing mutual TLS integration test:

- Positive: credential store with cert auth (no credential-reference)
  exercises full CRUD operations and asserts read-aliases result.
- Negative: credential store without token fails when cert auth is not
  enabled on Vault, asserting the specific error message.

Cert auth setup is extracted into enableVaultCertAuth() helper to avoid
duplication between ElytronSetup and the negative test's finally block.