### PR TITLE
Upgrade to version 1.1.0.CR1 of the vault library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <version.org.wildfly.plugins.wildfly-maven-plugin>5.1.3.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
 
         <version.vault.java.driver>6.2.1</version.vault.java.driver>
-        <version.wildfly.elytron.hashicorp.vault>1.0.1.Final</version.wildfly.elytron.hashicorp.vault>
+        <version.wildfly.elytron.hashicorp.vault>1.1.0.CR1</version.wildfly.elytron.hashicorp.vault>
         <version.org.apache.maven.plugins.maven-assembly-plugin>3.2.0</version.org.apache.maven.plugins.maven-assembly-plugin>
         <version.org.wildfly>40.0.0.Final</version.org.wildfly>
         <version.org.wildfly.common>2.0.1</version.org.wildfly.common>
@@ -326,7 +326,7 @@
                                     <reportsDirectory>${project.build.directory}/surefire-reports-java17-${jdk.test.vendor}</reportsDirectory>
                                 </configuration>
                             </execution>
-                            
+
                             <!-- Test with Java 21 -->
                             <execution>
                                 <id>test-java-21</id>
@@ -341,7 +341,7 @@
                                     <reportsDirectory>${project.build.directory}/surefire-reports-java21-${jdk.test.vendor}</reportsDirectory>
                                 </configuration>
                             </execution>
-                            
+
                             <!-- Test with Java 25 -->
                             <execution>
                                 <id>test-java-25</id>

--- a/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/CredentialStoreDefinition.java
+++ b/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/CredentialStoreDefinition.java
@@ -144,6 +144,7 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition PATH = new SimpleAttributeDefinitionBuilder("path", ModelType.STRING, true)
+            .setMinSize(0)  // Allow empty string to list all aliases
             .setStability(Stability.DEFAULT)
             .build();
 
@@ -374,20 +375,21 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
             ModelNode pathNode = PATH.resolveModelAttribute(context, operation);
             String path = pathNode.asStringOrNull();
 
+            // "#" means root of the default mount in the new alias format
             if (path == null || path.trim().isEmpty()) {
-                aliases = credentialStore.getAliases();
-            } else {
-                boolean recursive = RECURSIVE.resolveModelAttribute(context, operation).asBooleanOrNull();
-                int recursiveDepth = recursive ? RECURSIVE_DEPTH.resolveModelAttribute(context, operation).asIntOrNull() : 0;
-                int maxNumberOfAliases = MAX_NUMBER_OF_ALIASES.resolveModelAttribute(context, operation).asIntOrNull();
-
-                List<Class<? extends CredentialStoreExtension>> supportedTypes = credentialStore.getSupportedExtensionTypes();
-                if (!supportedTypes.contains(HashicorpVaultCredentialStoreExtension.class)) {
-                    throw HashiCorpVaultLogger.ROOT_LOGGER.vaultCredentialStoreExtensionNotSupported();
-                }
-                HashicorpVaultCredentialStoreExtension hccse = credentialStore.getExtensionInstance(HashicorpVaultCredentialStoreExtension.class);
-                aliases = hccse.getAliases(path, recursive, recursiveDepth, maxNumberOfAliases);
+                path = "#";
             }
+
+            boolean recursive = RECURSIVE.resolveModelAttribute(context, operation).asBooleanOrNull();
+            int recursiveDepth = recursive ? RECURSIVE_DEPTH.resolveModelAttribute(context, operation).asIntOrNull() : 0;
+            int maxNumberOfAliases = MAX_NUMBER_OF_ALIASES.resolveModelAttribute(context, operation).asIntOrNull();
+
+            List<Class<? extends CredentialStoreExtension>> supportedTypes = credentialStore.getSupportedExtensionTypes();
+            if (!supportedTypes.contains(HashicorpVaultCredentialStoreExtension.class)) {
+                throw HashiCorpVaultLogger.ROOT_LOGGER.vaultCredentialStoreExtensionNotSupported();
+            }
+            HashicorpVaultCredentialStoreExtension hccse = credentialStore.getExtensionInstance(HashicorpVaultCredentialStoreExtension.class);
+            aliases = hccse.getAliases(path, recursive, recursiveDepth, maxNumberOfAliases);
 
             List<ModelNode> list = new ArrayList<>();
             for (String alias : aliases) {

--- a/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/CredentialStoreDefinition.java
+++ b/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/CredentialStoreDefinition.java
@@ -251,7 +251,7 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
             // At DEFAULT stability or higher: legacy support is disabled (new format required)
             Stability stability = context.getStability();
             boolean supportLegacyFormat = stability.enables(Stability.COMMUNITY);
-            attributes.put("supportLegacyAliasFormat", String.valueOf(supportLegacyFormat));
+            attributes.put("support-legacy-alias-format", String.valueOf(supportLegacyFormat));
 
             HashiCorpVaultLogger.ROOT_LOGGER.debugf(
                 "Initializing credential store '%s' with stability=%s, supportLegacyAliasFormat=%s",

--- a/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/CredentialStoreDefinition.java
+++ b/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/CredentialStoreDefinition.java
@@ -117,7 +117,7 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
             .Builder.of(CREDENTIAL_STORE_CAPABILITY, true, CredentialStore.class)
             .build();
 
-    static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE = 
+    static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE =
             CredentialReference.getAttributeBuilder("credential-reference", "credential-reference", true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setCapabilityReference(CREDENTIAL_STORE_CAPABILITY, CREDENTIAL_STORE_RUNTIME_CAPABILITY)
@@ -128,9 +128,9 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
     public static final Collection<AttributeDefinition> ATTRIBUTES = List.of(HOST_NAME_DEF, NAMESPACE_DEF,
             AUTHENTICATION_CONTEXT_DEF, CREDENTIAL_REFERENCE);
 
-    static final StandardResourceDescriptionResolver OPERATION_RESOLVER = 
-            new StandardResourceDescriptionResolver("credential-store.operations", 
-                    "org.wildfly.extension.hashicorp.vault.LocalDescriptions", 
+    static final StandardResourceDescriptionResolver OPERATION_RESOLVER =
+            new StandardResourceDescriptionResolver("credential-store.operations",
+                    "org.wildfly.extension.hashicorp.vault.LocalDescriptions",
                     CredentialStoreDefinition.class.getClassLoader());
 
     static final SimpleAttributeDefinition ALIAS = new SimpleAttributeDefinitionBuilder("alias", ModelType.STRING, false)
@@ -228,7 +228,7 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
                 HashiCorpVaultLogger.ROOT_LOGGER.credentialReferenceRollbackFailed(e);
             }
         }
-        
+
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
             final String name = context.getCurrentAddressValue();
@@ -244,6 +244,17 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
             if (namespaceNode.isDefined()) {
                 attributes.put("namespace", namespaceNode.asString());
             }
+
+            // Enable legacy alias format support based on runtime stability level
+            // At COMMUNITY stability or lower: legacy support is enabled (with deprecation warnings)
+            // At DEFAULT stability or higher: legacy support is disabled (new format required)
+            Stability stability = context.getStability();
+            boolean supportLegacyFormat = stability.enables(Stability.COMMUNITY);
+            attributes.put("supportLegacyAliasFormat", String.valueOf(supportLegacyFormat));
+
+            HashiCorpVaultLogger.ROOT_LOGGER.debugf(
+                "Initializing credential store '%s' with stability=%s, supportLegacyAliasFormat=%s",
+                name, stability, supportLegacyFormat);
 
             SSLContext sslContext = null;
 
@@ -272,9 +283,9 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
             try {
                     ServiceName serviceName = CREDENTIAL_STORE_RUNTIME_CAPABILITY.getCapabilityServiceName(name);
 
-                    ExceptionSupplier<CredentialSource, Exception> credentialSourceSupplier = 
+                    ExceptionSupplier<CredentialSource, Exception> credentialSourceSupplier =
                             CredentialReference.getCredentialSourceSupplier(context, CREDENTIAL_REFERENCE, model, context.getServiceTarget().addService(ServiceName.of("temp", name)));
-                    
+
                     String token = null;
                     if (credentialSourceSupplier != null) {
                         try {
@@ -292,7 +303,7 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
                             throw HashiCorpVaultLogger.ROOT_LOGGER.failedToObtainCredentialFromReference(e);
                         }
                     }
-                    
+
                     CredentialStore.CredentialSourceProtectionParameter protectionParameter;
                     if (token != null) {
                         protectionParameter = new CredentialStore.CredentialSourceProtectionParameter(
@@ -307,7 +318,7 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
                     final Map<String, String> finalAttributes = attributes;
                     final CredentialStore.CredentialSourceProtectionParameter finalProtectionParameter = protectionParameter;
                     final Provider[] finalProviders = new Provider[]{WildFlyElytronPasswordProvider.getInstance()};
-                    
+
                     // Use the legacy addService pattern which supports ServiceController.getService()
                     // This is required for Elytron's credential-reference to work cross-subsystem
                 SSLContext finalSslContext = sslContext;
@@ -328,9 +339,9 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
                     if (credentialSourceSupplier != null) {
                         CredentialReference.getCredentialSourceSupplier(context, CREDENTIAL_REFERENCE, model, serviceBuilder);
                     }
-                    
+
                     serviceBuilder.install();
-                
+
             } catch (CredentialStoreException e) {
                 throw HashiCorpVaultLogger.ROOT_LOGGER.failedToInitializeHashiCorpVaultCredentialStore(e.getMessage(), e);
             } catch (Exception e) {
@@ -392,11 +403,11 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
         try {
             String alias = ALIAS.resolveModelAttribute(context, operation).asString();
             String secretValue = SECRET_VALUE.resolveModelAttribute(context, operation).asStringOrNull();
-            
+
             if (credentialStore.exists(alias, PasswordCredential.class)) {
                 throw HashiCorpVaultLogger.ROOT_LOGGER.credentialAliasAlreadyExists(alias);
             }
-            
+
             if (secretValue != null) {
                 PasswordCredential credential = createCredentialFromPassword(secretValue);
                 credentialStore.store(alias, credential);
@@ -414,11 +425,11 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
     private void removeAliasOperation(OperationContext context, ModelNode operation, CredentialStore credentialStore) throws OperationFailedException {
         try {
             String alias = ALIAS.resolveModelAttribute(context, operation).asString();
-            
+
             if (!credentialStore.exists(alias, PasswordCredential.class)) {
                 throw HashiCorpVaultLogger.ROOT_LOGGER.credentialAliasDoesNotExist(alias);
             }
-            
+
             credentialStore.remove(alias, PasswordCredential.class);
             credentialStore.flush();
         } catch (CredentialStoreException e) {
@@ -426,42 +437,42 @@ public class CredentialStoreDefinition extends SimpleResourceDefinition {
         }
     }
 
-    
+
     private static class RuntimeOperationHandler implements OperationStepHandler {
-        
+
         private final CredentialStoreOperation operation;
-        
+
         RuntimeOperationHandler(CredentialStoreOperation operation) {
             this.operation = operation;
         }
-        
+
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             context.addStep(new OperationStepHandler() {
                 @Override
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                     final String name = context.getCurrentAddressValue();
-                    
+
                     // Get the credential store from the service registry
                     ServiceName serviceName = CREDENTIAL_STORE_RUNTIME_CAPABILITY.getCapabilityServiceName(name);
                     ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
                     ServiceController<?> serviceController = serviceRegistry.getService(serviceName);
-                    
+
                     if (serviceController == null) {
                         throw HashiCorpVaultLogger.ROOT_LOGGER.credentialStoreResourceNotFound(name);
                     }
-                    
+
                     CredentialStore credentialStore = (CredentialStore) serviceController.getValue();
                     if (credentialStore == null) {
                         throw HashiCorpVaultLogger.ROOT_LOGGER.credentialStoreResourceNotAvailable(name);
                     }
-                    
+
                     RuntimeOperationHandler.this.operation.execute(context, operation, credentialStore);
                 }
             }, OperationContext.Stage.RUNTIME);
         }
     }
-    
+
     @FunctionalInterface
     private interface CredentialStoreOperation {
         void execute(OperationContext context, ModelNode operation, CredentialStore credentialStore) throws OperationFailedException;

--- a/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/VaultExtension.java
+++ b/subsystem/src/main/java/org/wildfly/extension/hashicorp/vault/VaultExtension.java
@@ -32,7 +32,7 @@ public final class VaultExtension implements Extension {
 
     static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
     //private static final String RESOURCE_NAME = VaultExtension.class.getPackage().getName() + ".LocalDescriptions";
-    
+
     public VaultExtension() {
     }
 
@@ -41,9 +41,10 @@ public final class VaultExtension implements Extension {
      */
     public enum VaultSubsystemModel implements SubsystemModel {
         VERSION_1_0_0(1, 0, 0),
+        VERSION_2_0_0(2, 0, 0),
         ;
 
-        static final VaultSubsystemModel CURRENT = VERSION_1_0_0;
+        static final VaultSubsystemModel CURRENT = VERSION_2_0_0;
 
         private final ModelVersion version;
 
@@ -76,12 +77,12 @@ public final class VaultExtension implements Extension {
         VaultExpressionResolver vaultResolver = new VaultExpressionResolver();
         context.registerExpressionResolverExtension(() -> vaultResolver, VAULT_EXPRESSION_PATTERN, false);
     }
-    
+
     @Override
     public void initializeParsers(org.jboss.as.controller.parsing.ExtensionParsingContext context) {
         context.setSubsystemXmlMappings(SUBSYSTEM_NAME, EnumSet.allOf(VaultSubsystemSchema.class));
     }
-    
+
     public static PathElement createPath(String name) {
         return PathElement.pathElement(name);
     }

--- a/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/AliasFormatFeatureIntegrationTestCase.java
+++ b/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/AliasFormatFeatureIntegrationTestCase.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.wildfly.extension.hashicorp.vault;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.version.Stability;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.vault.VaultContainer;
+
+/**
+ * Integration tests for new alias format features at DEFAULT stability level.
+ *
+ * Covers engine specification, custom mount points, multi-part secret paths,
+ * nested key paths, and legacy format rejection.
+ */
+public class AliasFormatFeatureIntegrationTestCase extends SubsystemJUnit5TestCase {
+
+    private static final String VAULT_TOKEN = "myroot";
+    private static final String CREDENTIAL_STORE_NAME = "vault-format-store";
+    private static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(
+            PathElement.pathElement("subsystem", VaultExtension.SUBSYSTEM_NAME));
+    private static final PathAddress CREDENTIAL_STORE_ADDRESS = SUBSYSTEM_ADDRESS.append("credential-store", CREDENTIAL_STORE_NAME);
+
+    private static VaultContainer<?> vault;
+
+    private KernelServices kernelServices;
+
+    private static synchronized void ensureVaultStarted() {
+        if (vault != null) {
+            return;
+        }
+        vault = new VaultContainer<>(DockerImageName.parse("hashicorp/vault:1.21"))
+                .withVaultToken(VAULT_TOKEN)
+                .withInitCommand(
+                        "secrets enable transit",
+                        "write -f transit/keys/my-key",
+                        "secrets enable -version=1 -path=secret-v1 kv",
+                        "secrets enable -version=2 -path=custom kv",
+                        "kv put secret/testing1 top_secret=password123",
+                        "kv put secret/testing2 dbuser=secretpass jmsuser=jmspass"
+                );
+        vault.start();
+    }
+
+    @BeforeClass
+    public static void startVault() {
+        ensureVaultStarted();
+    }
+
+    @AfterClass
+    public static void stopVault() {
+        if (vault != null) {
+            vault.stop();
+            vault = null;
+        }
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return new AdditionalInitialization.ManagementAdditionalInitialization(Stability.DEFAULT) {
+            @Override
+            protected RunningMode getRunningMode() {
+                return RunningMode.NORMAL;
+            }
+        };
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        ensureVaultStarted();
+        String hostAddress = vault.getHttpHostAddress();
+        return "<subsystem xmlns=\"urn:wildfly:hashicorp-vault:1.0\">\n"
+                + "    <credential-store name=\"" + CREDENTIAL_STORE_NAME + "\" host-address=\"" + hostAddress + "\">\n"
+                + "        <credential-reference clear-text=\"" + VAULT_TOKEN + "\"/>\n"
+                + "    </credential-store>\n"
+                + "</subsystem>";
+    }
+
+    @BeforeEach
+    public void bootKernel() throws Exception {
+        kernelServices = createKernelServicesBuilder(createAdditionalInitialization())
+                .setSubsystemXml(getSubsystemXml())
+                .build();
+        assertTrue(kernelServices.isSuccessfulBoot(), "Subsystem boot failed: " + kernelServices.getBootError());
+        kernelServices.getContainer().awaitStability();
+    }
+
+    // =====================================================================
+    // Engine specification
+    // =====================================================================
+
+    @Test
+    public void testAddAliasWithExplicitKVv2Engine() throws Exception {
+        String alias = "engine=KVv2#fmttest?engine_v2";
+        try {
+            ModelNode addResult = addAlias(alias, "engine-v2-value");
+            assertEquals(SUCCESS, addResult.get(OUTCOME).asString(), "add-alias should succeed: " + addResult);
+
+            ModelNode dupResult = addAlias(alias, "duplicate");
+            assertEquals("failed", dupResult.get(OUTCOME).asString(), "Duplicate add should fail: " + dupResult);
+            assertTrue(dupResult.get(FAILURE_DESCRIPTION).asString().contains("already exists"),
+                    "Should mention 'already exists': " + dupResult.get(FAILURE_DESCRIPTION).asString());
+        } finally {
+            removeAlias(alias);
+        }
+    }
+
+    @Test
+    public void testAddAliasWithKVv1EngineAndMount() throws Exception {
+        String alias = "engine=KVv1@secret-v1#fmttest?engine_v1";
+        try {
+            ModelNode addResult = addAlias(alias, "engine-v1-value");
+            assertEquals(SUCCESS, addResult.get(OUTCOME).asString(), "add-alias should succeed: " + addResult);
+
+            ModelNode dupResult = addAlias(alias, "duplicate");
+            assertEquals("failed", dupResult.get(OUTCOME).asString(), "Duplicate add should fail: " + dupResult);
+            assertTrue(dupResult.get(FAILURE_DESCRIPTION).asString().contains("already exists"),
+                    "Should mention 'already exists': " + dupResult.get(FAILURE_DESCRIPTION).asString());
+        } finally {
+            removeAlias(alias);
+        }
+    }
+
+    // =====================================================================
+    // Custom mount point
+    // =====================================================================
+
+    @Test
+    public void testAddAliasWithCustomMount() throws Exception {
+        String alias = "@custom#fmttest?custom_mount";
+        try {
+            ModelNode addResult = addAlias(alias, "custom-mount-value");
+            assertEquals(SUCCESS, addResult.get(OUTCOME).asString(), "add-alias should succeed: " + addResult);
+
+            ModelNode dupResult = addAlias(alias, "duplicate");
+            assertEquals("failed", dupResult.get(OUTCOME).asString(), "Duplicate add should fail: " + dupResult);
+            assertTrue(dupResult.get(FAILURE_DESCRIPTION).asString().contains("already exists"),
+                    "Should mention 'already exists': " + dupResult.get(FAILURE_DESCRIPTION).asString());
+        } finally {
+            removeAlias(alias);
+        }
+    }
+
+    // =====================================================================
+    // Combined engine + mount
+    // =====================================================================
+
+    @Test
+    public void testAddAliasWithCombinedKVv2EngineAndCustomMount() throws Exception {
+        String alias = "engine=KVv2@custom#fmttest?combined_v2";
+        try {
+            ModelNode addResult = addAlias(alias, "combined-v2-value");
+            assertEquals(SUCCESS, addResult.get(OUTCOME).asString(), "add-alias should succeed: " + addResult);
+
+            ModelNode dupResult = addAlias(alias, "duplicate");
+            assertEquals("failed", dupResult.get(OUTCOME).asString(), "Duplicate add should fail: " + dupResult);
+            assertTrue(dupResult.get(FAILURE_DESCRIPTION).asString().contains("already exists"),
+                    "Should mention 'already exists': " + dupResult.get(FAILURE_DESCRIPTION).asString());
+        } finally {
+            removeAlias(alias);
+        }
+    }
+
+    // =====================================================================
+    // Multi-part secret paths
+    // =====================================================================
+
+    @Test
+    public void testAddAliasWithMultiPartSecretPath() throws Exception {
+        String alias = "#myapp/database?multipath_key";
+        try {
+            ModelNode addResult = addAlias(alias, "multipath-value");
+            assertEquals(SUCCESS, addResult.get(OUTCOME).asString(), "add-alias should succeed: " + addResult);
+
+            ModelNode dupResult = addAlias(alias, "duplicate");
+            assertEquals("failed", dupResult.get(OUTCOME).asString(), "Duplicate add should fail: " + dupResult);
+            assertTrue(dupResult.get(FAILURE_DESCRIPTION).asString().contains("already exists"),
+                    "Should mention 'already exists': " + dupResult.get(FAILURE_DESCRIPTION).asString());
+        } finally {
+            removeAlias(alias);
+        }
+    }
+
+    // =====================================================================
+    // Nested key paths
+    // =====================================================================
+
+    @Test
+    public void testAddAliasWithNestedKeyPath() throws Exception {
+        String alias = "#fmttest?database/credentials/password";
+        try {
+            ModelNode addResult = addAlias(alias, "nested-password-value");
+            assertEquals(SUCCESS, addResult.get(OUTCOME).asString(), "add-alias should succeed: " + addResult);
+
+            ModelNode dupResult = addAlias(alias, "duplicate");
+            assertEquals("failed", dupResult.get(OUTCOME).asString(), "Duplicate add should fail: " + dupResult);
+            assertTrue(dupResult.get(FAILURE_DESCRIPTION).asString().contains("already exists"),
+                    "Should mention 'already exists': " + dupResult.get(FAILURE_DESCRIPTION).asString());
+        } finally {
+            removeAlias(alias);
+        }
+    }
+
+    // =====================================================================
+    // Legacy format rejection at DEFAULT stability
+    // =====================================================================
+
+    @Test
+    public void testLegacyDotFormatRejectedAtDefaultStability() throws Exception {
+        ModelNode result = addAlias("testing1.top_secret", "should-not-matter");
+        assertEquals("failed", result.get(OUTCOME).asString(),
+                "Legacy dot format should be rejected at DEFAULT stability: " + result);
+    }
+
+    @Test
+    public void testLegacySlashDotFormatRejectedAtDefaultStability() throws Exception {
+        ModelNode result = addAlias("secret/testing1.top_secret", "should-not-matter");
+        assertEquals("failed", result.get(OUTCOME).asString(),
+                "Legacy slash-dot format should be rejected at DEFAULT stability: " + result);
+    }
+
+    // =====================================================================
+    // Helpers
+    // =====================================================================
+
+    private ModelNode addAlias(String alias, String secretValue) throws Exception {
+        ModelNode op = Util.createOperation("add-alias", CREDENTIAL_STORE_ADDRESS);
+        op.get("alias").set(alias);
+        op.get("secret-value").set(secretValue);
+        return kernelServices.executeOperation(op);
+    }
+
+    private ModelNode removeAlias(String alias) throws Exception {
+        ModelNode op = Util.createOperation("remove-alias", CREDENTIAL_STORE_ADDRESS);
+        op.get("alias").set(alias);
+        return kernelServices.executeOperation(op);
+    }
+}

--- a/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/CredentialStoreVaultIntegrationTestCase.java
+++ b/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/CredentialStoreVaultIntegrationTestCase.java
@@ -144,7 +144,8 @@ public class CredentialStoreVaultIntegrationTestCase extends SubsystemJUnit5Test
 
     @Test
     public void testAddAliasReadAliasesRemoveAlias() throws Exception {
-        String alias = "secret/integration.test_secret";
+        String alias = "integration?test_secret";
+        String normalizedAlias = "#" + alias;  // read-aliases returns normalized format: #secretPath?key
         String secretValue = "my-secret-value";
 
         ModelNode addAlias = Util.createOperation("add-alias", CREDENTIAL_STORE_ADDRESS);
@@ -154,13 +155,13 @@ public class CredentialStoreVaultIntegrationTestCase extends SubsystemJUnit5Test
         assertEquals(SUCCESS, addResult.get(OUTCOME).asString(), "add-alias should succeed: " + addResult);
 
         ModelNode readAliases = Util.createOperation("read-aliases", CREDENTIAL_STORE_ADDRESS);
-        readAliases.get("path").set("secret");
+        readAliases.get("path").set("");  // Empty path = list all aliases
         readAliases.get("recursive").set(true);
         ModelNode readResult = kernelServices.executeOperation(readAliases);
         assertEquals(SUCCESS, readResult.get(OUTCOME).asString(), "read-aliases should succeed: " + readResult);
         List<ModelNode> aliasList = readResult.get(RESULT).asList();
         assertNotNull(aliasList);
-        assertTrue(aliasList.stream().anyMatch(n -> alias.equals(n.asString())), "Expected alias " + alias + " in " + aliasList);
+        assertTrue(aliasList.stream().anyMatch(n -> normalizedAlias.equals(n.asString())), "Expected alias " + normalizedAlias + " in " + aliasList);
 
         ModelNode removeAlias = Util.createOperation("remove-alias", CREDENTIAL_STORE_ADDRESS);
         removeAlias.get("alias").set(alias);
@@ -170,15 +171,17 @@ public class CredentialStoreVaultIntegrationTestCase extends SubsystemJUnit5Test
         ModelNode readAfter = kernelServices.executeOperation(readAliases);
         assertEquals(SUCCESS, readAfter.get(OUTCOME).asString(), "read-aliases after remove should succeed: " + readAfter);
         List<ModelNode> afterList = readAfter.get(RESULT).asList();
-        assertFalse(afterList != null && afterList.stream().anyMatch(n -> alias.equals(n.asString())), "Expected alias to be removed");
+        assertFalse(afterList != null && afterList.stream().anyMatch(n -> normalizedAlias.equals(n.asString())), "Expected alias to be removed");
     }
 
     @Test
     public void testAddMultipleAliasesAndListThem() throws Exception {
-        String alias1 = "secret/integration.alias_one";
-        String alias2 = "secret/integration.alias_two";
+        String alias1 = "integration?alias_one";
+        String alias2 = "integration?alias_two";
+        String normalizedAlias1 = "#" + alias1;  // read-aliases returns normalized format: #secretPath?key
+        String normalizedAlias2 = "#" + alias2;
         ModelNode readAliases = Util.createOperation("read-aliases", CREDENTIAL_STORE_ADDRESS);
-        readAliases.get("path").set("secret");
+        readAliases.get("path").set("");  // Empty path = list all aliases
         readAliases.get("recursive").set(true);
 
         for (String alias : new String[] { alias1, alias2 }) {
@@ -193,8 +196,8 @@ public class CredentialStoreVaultIntegrationTestCase extends SubsystemJUnit5Test
         assertEquals(SUCCESS, readResult.get(OUTCOME).asString(), "read-aliases should succeed: " + readResult);
         List<ModelNode> list = readResult.get(RESULT).asList();
         assertNotNull(list);
-        assertTrue(list.stream().anyMatch(n -> alias1.equals(n.asString())), "Expected " + alias1);
-        assertTrue(list.stream().anyMatch(n -> alias2.equals(n.asString())), "Expected " + alias2);
+        assertTrue(list.stream().anyMatch(n -> normalizedAlias1.equals(n.asString())), "Expected " + normalizedAlias1);
+        assertTrue(list.stream().anyMatch(n -> normalizedAlias2.equals(n.asString())), "Expected " + normalizedAlias2);
 
         for (String alias : new String[] { alias1, alias2 }) {
             ModelNode remove = Util.createOperation("remove-alias", CREDENTIAL_STORE_ADDRESS);
@@ -204,8 +207,8 @@ public class CredentialStoreVaultIntegrationTestCase extends SubsystemJUnit5Test
         }
 
         List<ModelNode> afterList = kernelServices.executeOperation(readAliases).get(RESULT).asList();
-        assertFalse(afterList != null && afterList.stream().anyMatch(n -> alias1.equals(n.asString())), "Expected alias1 removed");
-        assertFalse(afterList != null && afterList.stream().anyMatch(n -> alias2.equals(n.asString())), "Expected alias2 removed");
+        assertFalse(afterList != null && afterList.stream().anyMatch(n -> normalizedAlias1.equals(n.asString())), "Expected alias1 removed");
+        assertFalse(afterList != null && afterList.stream().anyMatch(n -> normalizedAlias2.equals(n.asString())), "Expected alias2 removed");
     }
 
     // =====================================================================
@@ -218,7 +221,7 @@ public class CredentialStoreVaultIntegrationTestCase extends SubsystemJUnit5Test
      */
     @Test
     public void testAddAliasThatAlreadyExists() throws Exception {
-        String alias = "secret/duplicate.error_test";
+        String alias = "duplicate?error_test";
 
         ModelNode addAlias = Util.createOperation("add-alias", CREDENTIAL_STORE_ADDRESS);
         addAlias.get("alias").set(alias);
@@ -247,7 +250,7 @@ public class CredentialStoreVaultIntegrationTestCase extends SubsystemJUnit5Test
     @Test
     public void testRemoveAliasThatDoesNotExist() throws Exception {
         ModelNode removeAlias = Util.createOperation("remove-alias", CREDENTIAL_STORE_ADDRESS);
-        removeAlias.get("alias").set("secret/nonexistent.no_such_key");
+        removeAlias.get("alias").set("nonexistent?no_such_key");
         ModelNode result = kernelServices.executeOperation(removeAlias);
         assertEquals("failed", result.get(OUTCOME).asString(), "Remove of non-existent alias should fail: " + result);
         assertTrue(result.get(FAILURE_DESCRIPTION).asString().contains("does not exist"),
@@ -261,7 +264,7 @@ public class CredentialStoreVaultIntegrationTestCase extends SubsystemJUnit5Test
     @Test
     public void testAddAliasWithoutSecretValue() throws Exception {
         ModelNode addAlias = Util.createOperation("add-alias", CREDENTIAL_STORE_ADDRESS);
-        addAlias.get("alias").set("secret/missing.secret_value");
+        addAlias.get("alias").set("missing?secret_value");
         // Deliberately omit secret-value
         ModelNode result = kernelServices.executeOperation(addAlias);
         assertEquals("failed", result.get(OUTCOME).asString(),

--- a/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/HashiCorpVaultCrudIntegrationTestCase.java
+++ b/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/HashiCorpVaultCrudIntegrationTestCase.java
@@ -128,7 +128,8 @@ public class HashiCorpVaultCrudIntegrationTestCase {
      */
     @Test
     public void testFullCrudLifecycle(@ArquillianResource ManagementClient managementClient) throws IOException {
-        String alias = "secret/crud.lifecycle_secret";
+        String alias = "crud?lifecycle_secret";
+        String normalizedAlias = "#" + alias;  // read-aliases returns normalized format: #secretPath?key
         String secretValue = "test-lifecycle-value-123";
 
         ModelNode addAlias = Util.createOperation(OP_ADD_ALIAS, CREDENTIAL_STORE_ADDRESS);
@@ -138,14 +139,14 @@ public class HashiCorpVaultCrudIntegrationTestCase {
         assertEquals(SUCCESS, addResult.get(OUTCOME).asString(), "add-alias should succeed: " + addResult);
 
         ModelNode readAliases = Util.createOperation(OP_READ_ALIASES, CREDENTIAL_STORE_ADDRESS);
-        readAliases.get(ATTR_PATH).set("secret");
+        readAliases.get(ATTR_PATH).set("");  // Empty path = list all aliases
         readAliases.get(ATTR_RECURSIVE).set(true);
         ModelNode readResult = executeOperation(managementClient, readAliases);
         assertEquals(SUCCESS, readResult.get(OUTCOME).asString(), "read-aliases should succeed: " + readResult);
         List<ModelNode> aliases = readResult.get(RESULT).asList();
         assertNotNull(aliases, "Alias list should not be null");
-        assertTrue(aliases.stream().anyMatch(n -> alias.equals(n.asString())),
-                "Expected alias '" + alias + "' to be present after add, got: " + aliases);
+        assertTrue(aliases.stream().anyMatch(n -> normalizedAlias.equals(n.asString())),
+                "Expected alias '" + normalizedAlias + "' to be present after add, got: " + aliases);
 
         ModelNode removeAlias = Util.createOperation(OP_REMOVE_ALIAS, CREDENTIAL_STORE_ADDRESS);
         removeAlias.get(ATTR_ALIAS).set(alias);
@@ -155,7 +156,7 @@ public class HashiCorpVaultCrudIntegrationTestCase {
         ModelNode readAfter = executeOperation(managementClient, readAliases);
         assertEquals(SUCCESS, readAfter.get(OUTCOME).asString(), "read-aliases after remove should succeed: " + readAfter);
         List<ModelNode> afterList = readAfter.get(RESULT).asList();
-        assertFalse(afterList != null && afterList.stream().anyMatch(n -> alias.equals(n.asString())),
+        assertFalse(afterList != null && afterList.stream().anyMatch(n -> normalizedAlias.equals(n.asString())),
                 "Alias should no longer be present after removal");
     }
 
@@ -164,8 +165,10 @@ public class HashiCorpVaultCrudIntegrationTestCase {
      */
     @Test
     public void testAddMultipleAliasesAndListThem(@ArquillianResource ManagementClient managementClient) throws IOException {
-        String alias1 = "secret/crud.multi_one";
-        String alias2 = "secret/crud.multi_two";
+        String alias1 = "crud?multi_one";
+        String alias2 = "crud?multi_two";
+        String normalizedAlias1 = "#" + alias1;  // read-aliases returns normalized format: #secretPath?key
+        String normalizedAlias2 = "#" + alias2;
 
         for (String alias : new String[] { alias1, alias2 }) {
             ModelNode add = Util.createOperation(OP_ADD_ALIAS, CREDENTIAL_STORE_ADDRESS);
@@ -176,14 +179,14 @@ public class HashiCorpVaultCrudIntegrationTestCase {
         }
 
         ModelNode readAliases = Util.createOperation(OP_READ_ALIASES, CREDENTIAL_STORE_ADDRESS);
-        readAliases.get(ATTR_PATH).set("secret");
+        readAliases.get(ATTR_PATH).set("");  // Empty path = list all aliases
         readAliases.get(ATTR_RECURSIVE).set(true);
         ModelNode readResult = executeOperation(managementClient, readAliases);
         assertEquals(SUCCESS, readResult.get(OUTCOME).asString(), "read-aliases should succeed: " + readResult);
         List<ModelNode> list = readResult.get(RESULT).asList();
         assertNotNull(list);
-        assertTrue(list.stream().anyMatch(n -> alias1.equals(n.asString())), "Expected " + alias1);
-        assertTrue(list.stream().anyMatch(n -> alias2.equals(n.asString())), "Expected " + alias2);
+        assertTrue(list.stream().anyMatch(n -> normalizedAlias1.equals(n.asString())), "Expected " + normalizedAlias1);
+        assertTrue(list.stream().anyMatch(n -> normalizedAlias2.equals(n.asString())), "Expected " + normalizedAlias2);
 
         for (String alias : new String[] { alias1, alias2 }) {
             ModelNode remove = Util.createOperation(OP_REMOVE_ALIAS, CREDENTIAL_STORE_ADDRESS);
@@ -194,9 +197,9 @@ public class HashiCorpVaultCrudIntegrationTestCase {
 
         ModelNode afterRead = executeOperation(managementClient, readAliases);
         List<ModelNode> afterList = afterRead.get(RESULT).asList();
-        assertFalse(afterList != null && afterList.stream().anyMatch(n -> alias1.equals(n.asString())),
+        assertFalse(afterList != null && afterList.stream().anyMatch(n -> normalizedAlias1.equals(n.asString())),
                 "Expected alias1 removed");
-        assertFalse(afterList != null && afterList.stream().anyMatch(n -> alias2.equals(n.asString())),
+        assertFalse(afterList != null && afterList.stream().anyMatch(n -> normalizedAlias2.equals(n.asString())),
                 "Expected alias2 removed");
     }
 
@@ -211,7 +214,7 @@ public class HashiCorpVaultCrudIntegrationTestCase {
      */
     @Test
     public void testSecretAccessibleFromDeployedApplication(@ArquillianResource ManagementClient managementClient) throws Exception {
-        String alias = "secret/crud.servlet_test";
+        String alias = "crud?servlet_test";
         String secretValue = "servlet-accessed-secret-42";
 
         ModelNode addAlias = Util.createOperation(OP_ADD_ALIAS, CREDENTIAL_STORE_ADDRESS);
@@ -243,7 +246,7 @@ public class HashiCorpVaultCrudIntegrationTestCase {
     @Test
     public void testDeployedApplicationReturnsNotFoundForMissingAlias(@ArquillianResource ManagementClient managementClient) throws Exception {
         URI servletUri = URI.create("http://127.0.0.1:8080/vault-crud-test/vault-secret"
-                + "?store=" + CREDENTIAL_STORE_NAME + "&alias=secret/crud.nonexistent_alias");
+                + "?store=" + CREDENTIAL_STORE_NAME + "&alias=crud?nonexistent_alias");
         HttpResponse<String> response = HttpClient.newHttpClient()
                 .send(HttpRequest.newBuilder(servletUri).GET().build(), HttpResponse.BodyHandlers.ofString());
 
@@ -262,7 +265,7 @@ public class HashiCorpVaultCrudIntegrationTestCase {
      */
     @Test
     public void testResolveExpressionDoesNotLeakSecret(@ArquillianResource ManagementClient managementClient) throws IOException {
-        String alias = "secret/crud.leak_test";
+        String alias = "crud?leak_test";
         String secretValue = "must-not-leak";
 
         ModelNode addAlias = Util.createOperation(OP_ADD_ALIAS, CREDENTIAL_STORE_ADDRESS);
@@ -298,7 +301,7 @@ public class HashiCorpVaultCrudIntegrationTestCase {
      */
     @Test
     public void testAddDuplicateAliasFails(@ArquillianResource ManagementClient managementClient) throws IOException {
-        String alias = "secret/crud.duplicate_test";
+        String alias = "crud?duplicate_test";
 
         ModelNode add1 = Util.createOperation(OP_ADD_ALIAS, CREDENTIAL_STORE_ADDRESS);
         add1.get(ATTR_ALIAS).set(alias);
@@ -329,7 +332,7 @@ public class HashiCorpVaultCrudIntegrationTestCase {
     @Test
     public void testRemoveNonExistentAliasFails(@ArquillianResource ManagementClient managementClient) throws IOException {
         ModelNode removeAlias = Util.createOperation(OP_REMOVE_ALIAS, CREDENTIAL_STORE_ADDRESS);
-        removeAlias.get(ATTR_ALIAS).set("secret/crud.no_such_key");
+        removeAlias.get(ATTR_ALIAS).set("crud?no_such_key");
         ModelNode result = executeOperation(managementClient, removeAlias);
         assertEquals("failed", result.get(OUTCOME).asString(),
                 "Remove of non-existent alias should fail: " + result);
@@ -343,7 +346,7 @@ public class HashiCorpVaultCrudIntegrationTestCase {
     @Test
     public void testAddAliasWithoutSecretValueFails(@ArquillianResource ManagementClient managementClient) throws IOException {
         ModelNode addAlias = Util.createOperation(OP_ADD_ALIAS, CREDENTIAL_STORE_ADDRESS);
-        addAlias.get(ATTR_ALIAS).set("secret/crud.no_secret");
+        addAlias.get(ATTR_ALIAS).set("crud?no_secret");
         // Deliberately omit secret-value
         ModelNode result = executeOperation(managementClient, addAlias);
         assertEquals("failed", result.get(OUTCOME).asString(),

--- a/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCase.java
+++ b/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCase.java
@@ -108,22 +108,24 @@ public class HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCas
         add.get("authentication-context").set(NAMES.authenticationContext);
         VaultHttpsElytronSetup.executeSuccess(managementClient, add);
 
+        String alias = "certtest?password";
+        String normalizedAlias = "#" + alias;  // read-aliases returns normalized format: #secretPath?key
         ModelNode addAlias = Util.createOperation("add-alias", storeAddress);
-        addAlias.get("alias").set("secret/certtest.password");
+        addAlias.get("alias").set(alias);
         addAlias.get("secret-value").set("s3cr3t");
         VaultHttpsElytronSetup.executeSuccess(managementClient, addAlias);
 
         ModelNode readAliases = Util.createOperation("read-aliases", storeAddress);
-        readAliases.get("path").set("secret/certtest");
+        readAliases.get("path").set("");  // Empty path = list all aliases
         readAliases.get("recursive").set(true);
         ModelNode readResult = managementClient.getControllerClient().execute(readAliases);
         assertEquals(SUCCESS, readResult.get(OUTCOME).asString(), "read-aliases should succeed: " + readResult);
         List<ModelNode> aliases = readResult.get(RESULT).asList();
-        assertTrue(aliases.stream().anyMatch(n -> "secret/certtest.password".equals(n.asString())),
-                "Expected alias 'secret/certtest.password' in read-aliases result, got: " + aliases);
+        assertTrue(aliases.stream().anyMatch(n -> normalizedAlias.equals(n.asString())),
+                "Expected alias '" + normalizedAlias + "' in read-aliases result, got: " + aliases);
 
         ModelNode removeAlias = Util.createOperation("remove-alias", storeAddress);
-        removeAlias.get("alias").set("secret/certtest.password");
+        removeAlias.get("alias").set(alias);  // Use the new format alias
         VaultHttpsElytronSetup.executeSuccess(managementClient, removeAlias);
 
         ModelNode remove = Util.createRemoveOperation(storeAddress);
@@ -135,7 +137,9 @@ public class HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCas
      * Credential store without token and without cert auth enabled on Vault.
      * The client certificate is presented at the TLS level but Vault has no {@code cert} auth method,
      * so all login strategies fail.
-     * <p><b>Passes when:</b> the credential store add operation fails.
+     * <p>The credential store add succeeds because Vault connections are created lazily.
+     * Authentication failure is detected on the first operation that contacts Vault.
+     * <p><b>Passes when:</b> the first vault operation after add fails with "All login strategies failed".
      */
     @Test
     public void testCredentialStoreWithoutTokenFailsWhenCertAuthNotEnabled(@ArquillianResource ManagementClient managementClient) throws Exception {
@@ -148,9 +152,16 @@ public class HashiCorpVaultHttpsMutualTlsAuthenticationContextIntegrationTestCas
             add.get("host-address").set(VAULT.composeHttpsHostAddress());
             add.get("authentication-context").set(NAMES.authenticationContext);
 
-            ModelNode response = managementClient.getControllerClient().execute(add);
+            ModelNode addResponse = managementClient.getControllerClient().execute(add);
+            assertEquals(SUCCESS, addResponse.get(OUTCOME).asString(),
+                    "Credential store add should succeed (connections are lazy): " + addResponse);
+
+            ModelNode readAliases = Util.createOperation("read-aliases", storeAddress);
+            readAliases.get("path").set("#");
+            readAliases.get("recursive").set(true);
+            ModelNode response = managementClient.getControllerClient().execute(readAliases);
             assertNotEquals(SUCCESS, response.get(OUTCOME).asString(),
-                    "Credential store add should fail without token and without cert auth enabled on Vault");
+                    "First vault operation should fail without token and without cert auth enabled on Vault");
             assertTrue(response.get(FAILURE_DESCRIPTION).toString().contains("All login strategies failed"),
                     "Expected 'All login strategies failed' in failure description, got: " + response.get(FAILURE_DESCRIPTION));
         } finally {

--- a/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/VaultExpressionResolverIntegrationTestCase.java
+++ b/testsuite/src/test/java/org/wildfly/extension/hashicorp/vault/VaultExpressionResolverIntegrationTestCase.java
@@ -111,7 +111,7 @@ public class VaultExpressionResolverIntegrationTestCase extends SubsystemJUnit5T
 
     @Test
     public void resolveExpressionReturnsStoredSecret() {
-        String alias = "secret/integration.resolver_test";
+        String alias = "integration?resolver_test";
         String secretValue = "resolved-secret-value";
 
         ModelNode addAlias = Util.createOperation("add-alias", CREDENTIAL_STORE_ADDRESS);
@@ -129,7 +129,7 @@ public class VaultExpressionResolverIntegrationTestCase extends SubsystemJUnit5T
 
     @Test
     public void resolveExpressionThrowsWhenAliasNotFound() {
-        String expression = "${HC_VAULT::" + CREDENTIAL_STORE_NAME + ":secret/nonexistent.missing}";
+        String expression = "${HC_VAULT::" + CREDENTIAL_STORE_NAME + ":nonexistent?missing}";
         OperationContext ctx = mockContextRuntime(kernelServices.getContainer());
 
         ExpressionResolver.ExpressionResolutionUserException e = assertThrows(
@@ -140,7 +140,7 @@ public class VaultExpressionResolverIntegrationTestCase extends SubsystemJUnit5T
 
     @Test
     public void resolveExpressionThrowsWhenStoreNotInstalled() {
-        String expression = "${HC_VAULT::no-such-store:secret/some.key}";
+        String expression = "${HC_VAULT::no-such-store:some?key}";
         OperationContext ctx = mockContextRuntime(kernelServices.getContainer());
 
         ExpressionResolver.ExpressionResolutionUserException e = assertThrows(


### PR DESCRIPTION
Within this PR we also:

- Enable legacy support for COMMUNITY stability and lower.
- Bump the management model to indicate the change.
- Update tests to use new alias format.
- Add test cases for KVv1
