### PR TITLE
Add expression resolution tests for new alias format

### DIFF
--- a/subsystem/src/test/java/org/wildfly/extension/hashicorp/vault/VaultExpressionResolverTestCase.java
+++ b/subsystem/src/test/java/org/wildfly/extension/hashicorp/vault/VaultExpressionResolverTestCase.java
@@ -4,9 +4,10 @@
  */
 package org.wildfly.extension.hashicorp.vault;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -19,17 +20,34 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
 
 /**
- * Basic tests for {@link VaultExpressionResolver}.
+ * Unit tests for {@link VaultExpressionResolver}.
+ *
+ * <p>The expression resolver parses expressions of the form {@code ${HC_VAULT::storeName:alias}},
+ * splitting on the first {@code :} after the {@code HC_VAULT::} prefix to extract the credential store name
+ * and the alias string. The alias is then passed verbatim to the credential store for retrieval.
+ *
+ * <p>These tests verify the resolver's own parsing logic — prefix detection, brace matching,
+ * store/alias extraction, and stage validation. No actual Vault connectivity is involved;
+ * a mock {@link OperationContext} is used throughout.
+ *
+ * <p>Actual alias format resolution (parsing {@code #}, {@code ?}, {@code @}, {@code engine=} etc.
+ * into mount path, secret path, and key path) is the responsibility of the credential store implementation
+ * in the upstream {@code wildfly-elytron-hashicorp-vault} library, tested by
+ * {@code VaultAliasParsingTestCase} there. End-to-end resolution against a real Vault instance is
+ * covered by {@code VaultExpressionResolverIntegrationTestCase} in the testsuite module.
  */
 public class VaultExpressionResolverTestCase {
 
     private VaultExpressionResolver resolver;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         resolver = new VaultExpressionResolver();
     }
@@ -61,7 +79,7 @@ public class VaultExpressionResolverTestCase {
         ExpressionResolver.ExpressionResolutionUserException e = assertThrows(
                 ExpressionResolver.ExpressionResolutionUserException.class,
                 () -> resolver.resolveExpression("${HC_VAULT::myStore:}", ctx));
-        assertTrue("Message should mention alias empty", e.getMessage().contains("alias is empty"));
+        assertTrue(e.getMessage().contains("alias is empty"), "Message should mention alias empty");
     }
 
     @Test
@@ -70,7 +88,7 @@ public class VaultExpressionResolverTestCase {
         ExpressionResolver.ExpressionResolutionServerException e = assertThrows(
                 ExpressionResolver.ExpressionResolutionServerException.class,
                 () -> resolver.resolveExpression("${HC_VAULT::myStore:myAlias}", ctx));
-        assertTrue("Message should mention MODEL", e.getMessage().contains("MODEL"));
+        assertTrue(e.getMessage().contains("MODEL"), "Message should mention MODEL");
     }
 
     @Test
@@ -79,8 +97,8 @@ public class VaultExpressionResolverTestCase {
         ExpressionResolver.ExpressionResolutionUserException e = assertThrows(
                 ExpressionResolver.ExpressionResolutionUserException.class,
                 () -> resolver.resolveExpression("${HC_VAULT::noSuchStore:someAlias}", ctx));
-        assertTrue("Message should mention not installed or not available",
-                e.getMessage().contains("not installed") || e.getMessage().contains("not available"));
+        assertTrue(e.getMessage().contains("not installed") || e.getMessage().contains("not available"),
+                "Message should mention not installed or not available");
     }
 
     @Test
@@ -94,6 +112,65 @@ public class VaultExpressionResolverTestCase {
     public void resolveExpressionThrowsOnNullContext() {
         assertThrows(IllegalArgumentException.class,
                 () -> resolver.resolveExpression("${HC_VAULT::s:a}", null));
+    }
+
+    /**
+     * Verifies that the expression resolver correctly extracts alias strings containing
+     * characters introduced by the new alias format (wildfly-elytron-hashicorp-vault PR #71):
+     * {@code [engine=TYPE][@mount-path][#]secret-path?key-path}.
+     *
+     * <p><b>Scenario:</b> Each alias is wrapped into {@code ${HC_VAULT::myStore:<alias>}} and
+     * passed to the resolver. Since the mock context has no credential store installed, the
+     * resolver is expected to throw an {@link ExpressionResolver.ExpressionResolutionUserException}
+     * with a message like:
+     * <pre>
+     * WFLYHCVT0028: Credential store 'myStore' is not installed for the expression: ${HC_VAULT::myStore:#secret?key}
+     * </pre>
+     *
+     * <p><b>What this proves:</b> The resolver's colon-based split ({@code indexOf(':')}) correctly
+     * separates the store name from the alias, even when the alias contains special characters
+     * ({@code #}, {@code ?}, {@code @}, {@code /}, {@code .}, {@code =}, {@code %}-encoded sequences,
+     * colons). If the store name is correctly extracted, the alias — being the complementary
+     * substring after the same split — must also be correct.
+     *
+     * <p><b>What this does not cover:</b> Parsing of the alias into its components (engine type,
+     * mount path, secret path, key path) and actual secret retrieval — those are tested in the
+     * upstream library and in the integration testsuite respectively.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "#secret?key",
+            "secret?key",
+            "myapp/database?password",
+            "#my.app.config?password",
+            "#myapp?db.host",
+            "#myapp?database/host",
+            "#myapp?app/config/database/host",
+            "#services?my.app/config.key",
+            "engine=KVv1#secret?key",
+            "@custom#secret?key",
+            "engine=KVv2@team/vault#app.db.config?api.key",
+            "#test%20path?password",
+            "#test%23path?key",
+            "#test%3Fpath?key",
+            "@mount%2Fname#secret%20path?key",
+            "@mount%40name#secret?key",
+            "#a?b",
+            "#my_app-v2?db_host-primary",
+            "#123/456?789",
+            "#secret?a/b/c/d/e",
+            "#secret:path?key",
+            "engine=KVv2@mount%20path#secret%23name?key%3Fname"
+    })
+    void resolveExpressionExtractsNewFormatAlias(String alias) {
+        OperationContext ctx = mockContext(OperationContext.Stage.RUNTIME);
+        String expression = "${HC_VAULT::myStore:" + alias + "}";
+        ExpressionResolver.ExpressionResolutionUserException e = assertThrows(
+                ExpressionResolver.ExpressionResolutionUserException.class,
+                () -> resolver.resolveExpression(expression, ctx));
+        assertInstanceOf(ExpressionResolver.ExpressionResolutionUserException.class, e);
+        assertTrue(e.getMessage().contains("'myStore'"),
+                "Store name should be correctly extracted from expression with alias '" + alias + "'");
     }
 
     private static OperationContext mockContext(OperationContext.Stage stage) {


### PR DESCRIPTION
Migrate VaultExpressionResolverTestCase to JUnit 5 and add a parameterized test verifying that alias strings using the new format from wildfly-elytron-hashicorp-vault PR #71 are correctly extracted from expressions. Covers all delimiter characters (#, ?, @, /), engine= prefix, URL-encoded sequences, and edge cases.